### PR TITLE
Correct wrong fileds of MX28 motor

### DIFF
--- a/dxl/dxlmotors.py
+++ b/dxl/dxlmotors.py
@@ -166,9 +166,9 @@ class DxlMotorMX28(DxlMotorAXMX):
     def __init__(self):
         DxlMotorAXMX.__init__(self)
 
-        self.registers["p_gain"]=               DxlRegisterByte(0x1A,'rw')
+        self.registers["d_gain"]=               DxlRegisterByte(0x1A,'rw')
         self.registers["i_gain"]=               DxlRegisterByte(0x1B,'rw')
-        self.registers["d_gain"]=               DxlRegisterByte(0x1C,'rw')
+        self.registers["p_gain"]=               DxlRegisterByte(0x1C,'rw')
         
         self.registers["goal_pos"]=             DxlRegisterWord(0x1E,'rw',range=[0,4095],tosi=self.pos_to_si,fromsi=self.si_to_pos)
         self.registers["moving_speed"]=         DxlRegisterWord(0x20,'rw',range=[0,1023],tosi=self.speed_to_si,fromsi=self.si_to_speed)

--- a/dxl/dxlmotors.py
+++ b/dxl/dxlmotors.py
@@ -159,9 +159,9 @@ class DxlMotorMX28(DxlMotorAXMX):
     __metaclass__=ModelRegisteringMetaclass
     model_name="MX28"
     model_number=29
-    documentation_url="http://support.robotis.com/en/product/dynamixel/rx_series/mx-28.htm"    
+    documentation_url="http://support.robotis.com/en/product/dynamixel/mx_series/mx-28.htm"
     tick_to_rad=0.00153588974175501002769284787627
-    tick_to_rpm=0.053
+    tick_to_rpm=0.114
 
     def __init__(self):
         DxlMotorAXMX.__init__(self)


### PR DESCRIPTION
Correct some fields of MX28 motor according to the user manual, such as tick_to_rpm, register address of PID gain.
