### PR TITLE
Improvements on reading out all memory addresses of servos.

### DIFF
--- a/dxl/dxlchain.py
+++ b/dxl/dxlchain.py
@@ -375,20 +375,6 @@ class DxlChain:
             delay=time.time()-start
             logging.debug("get_motor_list delay: %f"%delay)
             return l
-
-    def get_configuration(self,broadcast=True):
-        """Obtain the list of motors on a chain, read and return their full configuration"""
-        self.get_motor_list(broadcast=broadcast)
-        start=time.time()
-        d=OrderedDict()
-        for (id,m) in self.motors.items():
-            dd=OrderedDict()
-            d[id]=dd
-            for (name,r) in m.registers.items():
-                dd[name]=self.get_reg(id,name)
-        delay=time.time()-start
-        logging.debug("get_configuration reg delay: %f"%delay)
-        return d
         
     def set_configuration(self,conf):
         """Compare the motors available on a chain to those specified in the provided configuration, silently try to set all registers, generates an exception if there is a mismatch"""

--- a/dxl/dxlcore.py
+++ b/dxl/dxlcore.py
@@ -61,7 +61,12 @@ class DxlElement(object):
         mcls=cls.DxlModels[model_number]
         return mcls()
         
+    def getNameByAddr(self, addr):
+        for name in self.registers:
+            if self.registers[name].address == addr:
+                return name, self.registers[name].size
 
+        return None, None
         
     def getRegisterCmd(self,name):
         if not name in self.registers.keys():


### PR DESCRIPTION
Using this code you can read out the entire memory of a motor instead of requesting values for each address. As you can see in the commit name I've tested this with the ax-12a motors and saw significant improvemens in read time.

I however do not have access to other motors like this, so I am unable to test those. Although I've made sure that the code is very dynamic so it should work.